### PR TITLE
Submissions: show numbers

### DIFF
--- a/app/assets/stylesheets/pages/_submission-list-page.scss
+++ b/app/assets/stylesheets/pages/_submission-list-page.scss
@@ -80,6 +80,20 @@
   &:last-of-type {
     border-bottom: 2px solid $grey-default;
   }
+
+  tbody {
+    counter-reset: rowNumber;
+
+    tr {
+      counter-increment: rowNumber;
+
+      td:first-child::before {
+        content: counter(rowNumber);
+        min-width: 1em;
+        margin-right: 0.5em;
+      }
+    }
+  }
 }
 
 .submission-mobile-hidden {


### PR DESCRIPTION
Display numbers on submissions list because it's really helpful. CSS only.

<img width="1204" alt="screen shot 2017-01-17 at 23 41 20" src="https://cloud.githubusercontent.com/assets/68907/22043125/79b74d6c-dd0e-11e6-917a-8be84b569526.png">

(Also, removed the `no newline at the end of the file` warning )
