### PR TITLE
Fix amount of additional invitations

### DIFF
--- a/app/repositories/submission_repository.rb
+++ b/app/repositories/submission_repository.rb
@@ -77,8 +77,16 @@ class SubmissionRepository
   end
 
   def limit_to_invite_at_the_moment
-    limit = Setting.get.available_spots - invited_not_expired.length
+    limit = Setting.get.available_spots - confirmed_or_still_able_to_confirm_spots
     limit >= 0 ? limit : 0
+  end
+
+  def confirmed_or_still_able_to_confirm_spots
+    confirmed.length + invited_not_expired_not_confirmed.length
+  end
+
+  def confirmed
+    Submission.where('invitation_confirmed = ?', true)
   end
 
   def invited_not_expired

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -9,7 +9,9 @@ FactoryGirl.define do
     operating_system :windows
     first_time true
     goals "Tons of money!\nTons of money!\nTons of money!\n"
-    problems "I'm shortsighted - can't see money's a shitty goal. :c"
+    problems "I'm shortsighted - can't see money's a poor goal. :c"
+    invitation_confirmed false
+    invitation_token nil
     rejected false
 
     trait :with_rates do
@@ -21,6 +23,10 @@ FactoryGirl.define do
       after(:create) do |submission, ev|
         create_list(:rate, ev.rates_num, value: ev.rates_val, submission: submission)
       end
+    end
+
+    trait :invited do
+      sequence(:invitation_token) { |n| "#{n}#{n}#{n}"}
     end
   end
 end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -27,6 +27,7 @@ FactoryGirl.define do
 
     trait :invited do
       sequence(:invitation_token) { |n| "#{n}#{n}#{n}"}
+      invitation_token_created_at { 2.days.ago }
     end
   end
 end


### PR DESCRIPTION
Last year, we send too many additional invitations after not-confirmed ones from the initial batch expired. The problem was caused by the fact that confirmed invitations were not included in `invited_not_expired` and not counted properly. We survived that, but I would prefer not to repeat that experience.

The tests are quite ugly, but work :)