### PR TITLE
Fix ambiguous registration deadline

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -18,14 +18,16 @@ class SettingsController < ApplicationController
   private
 
   def setting_params
-    params.require(:setting).permit(:available_spots, :required_rates_num, :days_to_confirm_invitation,
-      :beginning_of_preparation_period, :beginning_of_registration_period, :beginning_of_closed_period,
-      :event_start_date, :event_end_date, :event_url, :event_venue)
+    params.require(:setting).permit(
+      :available_spots, :required_rates_num, :days_to_confirm_invitation,
+      :beginning_of_preparation_period, :beginning_of_registration_period, :end_of_registration_period,
+      :event_start_date, :event_end_date, :event_url, :event_venue
+    )
   end
 
   def dates_order_ok?(params)
     params[:beginning_of_preparation_period] < params[:beginning_of_registration_period] &&
-    params[:beginning_of_registration_period] < params[:beginning_of_closed_period] &&
+    params[:beginning_of_registration_period] <= params[:end_of_registration_period] &&
     params[:event_start_date] < params[:event_end_date]
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,4 +1,6 @@
 class Setting < ActiveRecord::Base
+  attr_accessor :end_of_registration_period
+
   validate :preparation_is_before_registration,
            :registration_is_before_closed,
            :start_is_before_end
@@ -15,6 +17,15 @@ class Setting < ActiveRecord::Base
             presence: true
   validates :available_spots, :required_rates_num, :days_to_confirm_invitation,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  def end_of_registration_period
+    (beginning_of_closed_period - 1.day).end_of_day
+  end
+
+  def end_of_registration_period=(value)
+    value = value.is_a?(Time) ? value : Time.zone.parse(value)
+    self.beginning_of_closed_period = (value + 1.day).beginning_of_day
+  end
 
   def self.get
     self.first || self.create({
@@ -38,7 +49,7 @@ class Setting < ActiveRecord::Base
     settings.days_to_confirm_invitation = setting_params[:days_to_confirm_invitation]
     settings.beginning_of_preparation_period = setting_params[:beginning_of_preparation_period]
     settings.beginning_of_registration_period = setting_params[:beginning_of_registration_period]
-    settings.beginning_of_closed_period = setting_params[:beginning_of_closed_period]
+    settings.end_of_registration_period = setting_params[:end_of_registration_period]
     settings.event_start_date = setting_params[:event_start_date]
     settings.event_end_date = setting_params[:event_end_date]
     settings.event_url = setting_params[:event_url]

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -16,7 +16,7 @@ class SettingPresenter
   end
 
   def registration_ends
-    present_date(setting.beginning_of_closed_period)
+    present_date(setting.end_of_registration_period)
   end
 
   def event_url

--- a/app/views/settings/_form.html.erb
+++ b/app/views/settings/_form.html.erb
@@ -9,8 +9,8 @@
     <%= f.date_field :beginning_of_registration_period, required: true %>
   </div>
   <div class="form-field">
-    <%= f.label "The registration ends on" %>
-    <%= f.date_field :beginning_of_closed_period, required: true %>
+    <%= f.label "The registration ends at 23:59 on" %>
+    <%= f.date_field :end_of_registration_period, required: true %>
   </div>
   <div class="form-field">
     <%= f.label "The event starts on" %>

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -4,7 +4,7 @@
       <%= footer_presenter.event_dates %>
     </span>
     <span class="end-date" itemprop="endDate">
-      Application form closes on <%= footer_presenter.registration_ends %>
+      Application form closes by the end of <%= footer_presenter.registration_ends %>
     </span>
   </h1>
 

--- a/spec/features/updating_settings_spec.rb
+++ b/spec/features/updating_settings_spec.rb
@@ -11,7 +11,7 @@ describe "testing updating settings:" do
     find("#setting_days_to_confirm_invitation").set(7)
     find("#setting_beginning_of_preparation_period").set("2016/06/21")
     find("#setting_beginning_of_registration_period").set("2016/06/22")
-    find("#setting_beginning_of_closed_period").set("2016/06/23")
+    find("#setting_end_of_registration_period").set("2016/06/22")
     find("#setting_event_venue").set("krakow")
 
     click_button "Save settings"

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -41,4 +41,20 @@ RSpec.describe Submission, type: :model do
     }
     expect(FactoryGirl.build(:setting, params)).not_to be_valid
   end
+
+  it "correctly calculates end_of_registration_period on read" do
+    beginning_of_closed_period = Time.zone.parse('2016-06-27')
+    expected_end_of_registration_period = Time.zone.parse('2016-06-26').end_of_day
+    setting = FactoryGirl.build(:setting, {beginning_of_closed_period: beginning_of_closed_period})
+
+    expect(setting.end_of_registration_period).to eq(expected_end_of_registration_period)
+  end
+
+  it "correctly calculates end_of_registration_period on write" do
+    end_of_registration_period = Time.zone.parse('2016-06-26')
+    expected_beginning_of_closed_period = Time.zone.parse('2016-06-27').beginning_of_day
+    setting = FactoryGirl.build(:setting, {end_of_registration_period: end_of_registration_period})
+
+    expect(setting.beginning_of_closed_period).to eq(expected_beginning_of_closed_period)
+  end
 end


### PR DESCRIPTION
The settings form used to say "The registration ends on 2019-05-27" and the submission form said "Application form closes on 27 May" when actually the registration ended on May 26th at midnight.

This commit fixes that by changing the settings form to say "The registration ends at 23:59 on 2019-05-26" and the submission form to say "Application form closes by the end of 26 May".

![rg before after](https://user-images.githubusercontent.com/27113/54073494-08ac3600-4288-11e9-8fc5-4d979be48f8c.png)