### PR TITLE
Fix authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'devise'
 
 gem 'omniauth-github'
+gem 'omniauth-rails_csrf_protection'
 
 gem 'whenever', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     pg (0.21.0)
     pry (0.10.4)
@@ -328,6 +331,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   omniauth-github
+  omniauth-rails_csrf_protection
   pg
   pry-rails
   quiet_assets


### PR DESCRIPTION
This PR fixes GH authentication to the admin panel.

**What happened?**

Authentication stopped working because [GH had deprecated authentication through query params](https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/).

**What fixed the issue?**

In order to comply with new requirements, `devise` and `omniauth-github` needed to be updated and [omniauth-rails_csrf_protection](https://github.com/LunarLogic/rails-girls-submissions/commit/ed17ddae3ab72cec28b86e3796e16a93c617d440) had to be added.

